### PR TITLE
Fix accumulator and refactor away the word "gauge"

### DIFF
--- a/src/RewardDistributor.sol
+++ b/src/RewardDistributor.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.16;
 // contracts
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Pausable} from "@openzeppelin/contracts/security/Pausable.sol";
-import {GaugeController} from "./GaugeController.sol";
+import {RewardController} from "./RewardController.sol";
 
 // interfaces
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -21,7 +21,7 @@ import {PRBMathUD60x18} from "prb-math/contracts/PRBMathUD60x18.sol";
 contract RewardDistributor is
     IRewardDistributor,
     IStakingContract,
-    GaugeController
+    RewardController
 {
     using SafeERC20 for IERC20Metadata;
     using PRBMathUD60x18 for uint256;
@@ -49,7 +49,7 @@ contract RewardDistributor is
     /// @dev First address is user, second is from ClearingHouse.perpetuals
     mapping(address => mapping(address => uint256)) public lpPositionsPerUser;
 
-    /// @notice Reward accumulator for total market rewards per reward token
+    /// @notice Reward accumulator for market rewards per reward token, as a number of reward tokens per LP token
     /// @dev First address is reward token, second is from ClearingHouse.perpetuals
     mapping(address => mapping(address => uint256))
         public cumulativeRewardPerLpToken;
@@ -79,8 +79,8 @@ contract RewardDistributor is
         address _rewardToken,
         address _clearingHouse,
         uint256 _earlyWithdrawalThreshold,
-        uint16[] memory _initialGaugeWeights
-    ) GaugeController(_initialInflationRate, _initialReductionFactor) {
+        uint16[] memory _initialRewardWeights
+    ) RewardController(_initialInflationRate, _initialReductionFactor) {
         clearingHouse = IClearingHouse(_clearingHouse);
         earlyWithdrawalThreshold = _earlyWithdrawalThreshold;
         // Add reward token info
@@ -89,13 +89,13 @@ contract RewardDistributor is
             initialTimestamp: block.timestamp,
             inflationRate: _initialInflationRate,
             reductionFactor: _initialReductionFactor,
-            gaugeWeights: _initialGaugeWeights
+            marketWeights: _initialRewardWeights
         });
-        for (uint256 i; i < getNumGauges(); ++i) {
-            uint256 idx = getGaugeIdx(i);
-            address gauge = getGaugeAddress(idx);
-            rewardTokensPerGauge[gauge].push(_rewardToken);
-            timeOfLastCumRewardUpdate[gauge] = block.timestamp;
+        for (uint256 i; i < getNumMarkets(); ++i) {
+            uint256 idx = getMarketIdx(i);
+            address market = getMarketAddress(idx);
+            rewardTokensPerMarket[market].push(_rewardToken);
+            timeOfLastCumRewardUpdate[market] = block.timestamp;
         }
         emit RewardTokenAdded(
             _rewardToken,
@@ -106,84 +106,84 @@ contract RewardDistributor is
     }
 
     /* ****************** */
-    /*       Gauges       */
+    /*      Markets       */
     /* ****************** */
 
-    /// @inheritdoc GaugeController
-    function getNumGauges() public view virtual override returns (uint256) {
+    /// @inheritdoc RewardController
+    function getNumMarkets() public view virtual override returns (uint256) {
         return clearingHouse.getNumMarkets();
     }
 
-    /// @inheritdoc GaugeController
-    function getMaxGaugeIdx() public view virtual override returns (uint256) {
+    /// @inheritdoc RewardController
+    function getMaxMarketIdx() public view virtual override returns (uint256) {
         return clearingHouse.marketIds() - 1;
     }
 
-    /// @inheritdoc GaugeController
-    function getGaugeAddress(
+    /// @inheritdoc RewardController
+    function getMarketAddress(
         uint256 index
     ) public view virtual override returns (address) {
-        if (index > getMaxGaugeIdx())
+        if (index > getMaxMarketIdx())
             revert RewardDistributor_InvalidMarketIndex(
                 index,
-                getMaxGaugeIdx()
+                getMaxMarketIdx()
             );
         return address(clearingHouse.perpetuals(index));
     }
 
-    /// @inheritdoc GaugeController
-    function getGaugeIdx(
+    /// @inheritdoc RewardController
+    function getMarketIdx(
         uint256 i
     ) public view virtual override returns (uint256) {
         return clearingHouse.id(i);
     }
 
-    /// @inheritdoc GaugeController
+    /// @inheritdoc RewardController
     function getAllowlistIdx(
         uint256 idx
     ) public view virtual override returns (uint256) {
-        for (uint i; i < getNumGauges(); ++i) {
-            if (getGaugeIdx(i) == idx) return i;
+        for (uint i; i < getNumMarkets(); ++i) {
+            if (getMarketIdx(i) == idx) return i;
         }
         revert RewardDistributor_MarketIndexNotAllowlisted(idx);
     }
 
-    /// Returns the current position of the user in the gauge (i.e., perpetual market)
+    /// Returns the current position of the user in the market (i.e., perpetual market)
     /// @param lp Address of the user
-    /// @param gauge Address of the gauge
-    /// @return Current position of the user in the gauge
+    /// @param market Address of the market
+    /// @return Current position of the user in the market
     function getCurrentPosition(
         address lp,
-        address gauge
+        address market
     ) public view virtual returns (uint256) {
-        return IPerpetual(gauge).getLpLiquidity(lp);
+        return IPerpetual(market).getLpLiquidity(lp);
     }
 
     /* ****************** */
     /*   Reward Accrual   */
     /* ****************** */
 
-    /// @inheritdoc GaugeController
+    /// @inheritdoc RewardController
     function updateMarketRewards(uint256 idx) public override {
-        address gauge = getGaugeAddress(idx);
-        uint256 liquidity = totalLiquidityPerMarket[gauge];
-        uint256 deltaTime = block.timestamp - timeOfLastCumRewardUpdate[gauge];
+        address market = getMarketAddress(idx);
+        uint256 liquidity = totalLiquidityPerMarket[market];
+        uint256 deltaTime = block.timestamp - timeOfLastCumRewardUpdate[market];
         if (liquidity == 0) {
-            timeOfLastCumRewardUpdate[gauge] = block.timestamp;
+            timeOfLastCumRewardUpdate[market] = block.timestamp;
             return;
         }
         uint256 allowlistIdx = getAllowlistIdx(idx);
-        for (uint256 i; i < rewardTokensPerGauge[gauge].length; ++i) {
-            address token = rewardTokensPerGauge[gauge][i];
+        for (uint256 i; i < rewardTokensPerMarket[market].length; ++i) {
+            address token = rewardTokensPerMarket[market][i];
             RewardInfo memory rewardInfo = rewardInfoByToken[token];
             if (
-                allowlistIdx >= rewardInfo.gaugeWeights.length ||
-                rewardInfo.gaugeWeights[allowlistIdx] == 0
+                allowlistIdx >= rewardInfo.marketWeights.length ||
+                rewardInfo.marketWeights[allowlistIdx] == 0
             ) continue;
-            uint16 gaugeWeight = rewardInfo.gaugeWeights[allowlistIdx];
-            // if (timeOfLastCumRewardUpdate[gauge] == 0 && gaugeWeight != 0)
+            uint16 marketWeight = rewardInfo.marketWeights[allowlistIdx];
+            // if (timeOfLastCumRewardUpdate[market] == 0 && marketWeight != 0)
             //     // shouldn't be possible
-            //     revert RewardDistributor_UninitializedStartTime(gauge);
+            //     revert RewardDistributor_UninitializedStartTime(market);
             uint256 totalTimeElapsed = block.timestamp -
                 rewardInfo.initialTimestamp;
             // Calculate the new cumRewardPerLpToken by adding (inflationRatePerSecond x guageWeight x deltaTime) to the previous cumRewardPerLpToken
@@ -194,13 +194,13 @@ contract RewardDistributor is
                     )
                 )
             );
-            uint256 newRewards = (((((inflationRate * gaugeWeight) / 10000) *
+            uint256 newRewards = (((((inflationRate * marketWeight) / 10000) *
                 deltaTime) / 365 days) * 1e18) / liquidity;
-            cumulativeRewardPerLpToken[token][gauge] += newRewards;
-            emit RewardAccruedToMarket(gauge, token, newRewards);
+            cumulativeRewardPerLpToken[token][market] += newRewards;
+            emit RewardAccruedToMarket(market, token, newRewards);
         }
         // Set timeOfLastCumRewardUpdate to the currentTime
-        timeOfLastCumRewardUpdate[gauge] = block.timestamp;
+        timeOfLastCumRewardUpdate[market] = block.timestamp;
     }
 
     /// Accrues rewards and updates the stored LP position of a user and the total LP of a market
@@ -212,31 +212,31 @@ contract RewardDistributor is
         address user
     ) external virtual override nonReentrant onlyClearingHouse {
         updateMarketRewards(idx);
-        address gauge = getGaugeAddress(idx);
-        uint256 prevLpPosition = lpPositionsPerUser[user][gauge];
-        uint256 newLpPosition = getCurrentPosition(user, gauge);
-        uint256 prevTotalLiquidity = totalLiquidityPerMarket[gauge];
-        for (uint256 i; i < rewardTokensPerGauge[gauge].length; ++i) {
-            address token = rewardTokensPerGauge[gauge][i];
+        address market = getMarketAddress(idx);
+        uint256 prevLpPosition = lpPositionsPerUser[user][market];
+        uint256 newLpPosition = getCurrentPosition(user, market);
+        uint256 prevTotalLiquidity = totalLiquidityPerMarket[market];
+        for (uint256 i; i < rewardTokensPerMarket[market].length; ++i) {
+            address token = rewardTokensPerMarket[market][i];
             /// newRewards = user.lpBalance / global.lpBalance x (global.cumRewardPerLpToken - user.cumRewardPerLpToken)
             uint256 newRewards = prevTotalLiquidity > 0
                 ? (prevLpPosition *
-                    (cumulativeRewardPerLpToken[token][gauge] -
+                    (cumulativeRewardPerLpToken[token][market] -
                         cumulativeRewardPerLpTokenPerUser[user][token][
-                            gauge
+                            market
                         ])) / 1e18
                 : 0;
             if (newLpPosition >= prevLpPosition) {
                 // Added liquidity
-                if (lastDepositTimeByUserByMarket[user][gauge] == 0) {
-                    lastDepositTimeByUserByMarket[user][gauge] = block
+                if (lastDepositTimeByUserByMarket[user][market] == 0) {
+                    lastDepositTimeByUserByMarket[user][market] = block
                         .timestamp;
                 }
             } else {
                 // Removed liquidity - need to check if within early withdrawal threshold
                 if (
                     block.timestamp -
-                        lastDepositTimeByUserByMarket[user][gauge] <
+                        lastDepositTimeByUserByMarket[user][market] <
                     earlyWithdrawalThreshold
                 ) {
                     // Early withdrawal - apply penalty
@@ -246,81 +246,83 @@ contract RewardDistributor is
                 }
                 if (newLpPosition > 0) {
                     // Reset timer
-                    lastDepositTimeByUserByMarket[user][gauge] = block
+                    lastDepositTimeByUserByMarket[user][market] = block
                         .timestamp;
                 } else {
                     // Full withdrawal, so next deposit is an initial deposit
-                    lastDepositTimeByUserByMarket[user][gauge] = 0;
+                    lastDepositTimeByUserByMarket[user][market] = 0;
                 }
             }
             rewardsAccruedByUser[user][token] += newRewards;
             totalUnclaimedRewards[token] += newRewards;
             cumulativeRewardPerLpTokenPerUser[user][token][
-                gauge
-            ] = cumulativeRewardPerLpToken[token][gauge];
-            emit RewardAccruedToUser(user, token, address(gauge), newRewards);
+                market
+            ] = cumulativeRewardPerLpToken[token][market];
+            emit RewardAccruedToUser(user, token, address(market), newRewards);
         }
-        totalLiquidityPerMarket[gauge] =
-            totalLiquidityPerMarket[gauge] +
+        totalLiquidityPerMarket[market] =
+            totalLiquidityPerMarket[market] +
             newLpPosition -
             prevLpPosition;
-        lpPositionsPerUser[user][gauge] = newLpPosition;
+        lpPositionsPerUser[user][market] = newLpPosition;
     }
 
     /* ****************** */
     /*     Governance     */
     /* ****************** */
 
-    /// Sets the start time for accruing rewards to a gauge which has not been initialized yet
-    /// @param _gauge Address of the gauge (i.e., perpetual market)
-    function initGaugeStartTime(address _gauge) external onlyRole(GOVERNANCE) {
-        if (timeOfLastCumRewardUpdate[_gauge] != 0)
-            revert RewardDistributor_AlreadyInitializedStartTime(_gauge);
-        timeOfLastCumRewardUpdate[_gauge] = block.timestamp;
+    /// Sets the start time for accruing rewards to a market which has not been initialized yet
+    /// @param _market Address of the market (i.e., perpetual market)
+    function initMarketStartTime(
+        address _market
+    ) external onlyRole(GOVERNANCE) {
+        if (timeOfLastCumRewardUpdate[_market] != 0)
+            revert RewardDistributor_AlreadyInitializedStartTime(_market);
+        timeOfLastCumRewardUpdate[_market] = block.timestamp;
     }
 
     /// Adds a new reward token
     /// @param _rewardToken Address of the reward token
     /// @param _initialInflationRate Initial inflation rate for the new token
     /// @param _initialReductionFactor Initial reduction factor for the new token
-    /// @param _gaugeWeights Initial weights per gauge/market for the new token
+    /// @param _marketWeights Initial weights per market for the new token
     function addRewardToken(
         address _rewardToken,
         uint256 _initialInflationRate,
         uint256 _initialReductionFactor,
-        uint16[] calldata _gaugeWeights
+        uint16[] calldata _marketWeights
     ) external nonReentrant onlyRole(GOVERNANCE) {
-        uint256 gaugesLength = getNumGauges();
-        if (_gaugeWeights.length != gaugesLength)
-            revert GaugeController_IncorrectWeightsCount(
-                _gaugeWeights.length,
-                gaugesLength
+        uint256 marketsLength = getNumMarkets();
+        if (_marketWeights.length != marketsLength)
+            revert RewardController_IncorrectWeightsCount(
+                _marketWeights.length,
+                marketsLength
             );
         // Validate weights
         uint16 totalWeight;
-        for (uint i; i < gaugesLength; ++i) {
-            uint256 idx = getGaugeIdx(i);
+        for (uint i; i < marketsLength; ++i) {
+            uint256 idx = getMarketIdx(i);
             updateMarketRewards(idx);
-            uint16 weight = _gaugeWeights[i];
+            uint16 weight = _marketWeights[i];
             if (weight == 0) continue;
             if (weight > 10000)
-                revert GaugeController_WeightExceedsMax(weight, 10000);
-            address gauge = getGaugeAddress(idx);
-            if (rewardTokensPerGauge[gauge].length >= MAX_REWARD_TOKENS)
-                revert GaugeController_AboveMaxRewardTokens(MAX_REWARD_TOKENS);
+                revert RewardController_WeightExceedsMax(weight, 10000);
+            address market = getMarketAddress(idx);
+            if (rewardTokensPerMarket[market].length >= MAX_REWARD_TOKENS)
+                revert RewardController_AboveMaxRewardTokens(MAX_REWARD_TOKENS);
             totalWeight += weight;
-            rewardTokensPerGauge[gauge].push(_rewardToken);
-            emit NewWeight(gauge, _rewardToken, weight);
+            rewardTokensPerMarket[market].push(_rewardToken);
+            emit NewWeight(market, _rewardToken, weight);
         }
         if (totalWeight != 10000)
-            revert GaugeController_IncorrectWeightsSum(totalWeight, 10000);
+            revert RewardController_IncorrectWeightsSum(totalWeight, 10000);
         // Add reward token info
         rewardInfoByToken[_rewardToken] = RewardInfo({
             token: IERC20Metadata(_rewardToken),
             initialTimestamp: block.timestamp,
             inflationRate: _initialInflationRate,
             reductionFactor: _initialReductionFactor,
-            gaugeWeights: _gaugeWeights
+            marketWeights: _marketWeights
         });
         emit RewardTokenAdded(
             _rewardToken,
@@ -338,23 +340,23 @@ contract RewardDistributor is
         if (
             _token == address(0) ||
             rewardInfoByToken[_token].token != IERC20Metadata(_token)
-        ) revert GaugeController_InvalidRewardTokenAddress(_token);
-        uint256 gaugesLength = getNumGauges();
+        ) revert RewardController_InvalidRewardTokenAddress(_token);
+        uint256 marketsLength = getNumMarkets();
         // Update rewards for all markets before removal
-        for (uint i; i < gaugesLength; ++i) {
+        for (uint i; i < marketsLength; ++i) {
             uint256 idx = clearingHouse.id(i);
-            address gauge = getGaugeAddress(idx);
+            address market = getMarketAddress(idx);
             updateMarketRewards(idx);
             // The `delete` keyword applied to arrays does not reduce array length
-            uint256 numRewards = rewardTokensPerGauge[gauge].length;
+            uint256 numRewards = rewardTokensPerMarket[market].length;
             for (uint j = 0; j < numRewards; ++j) {
-                if (rewardTokensPerGauge[gauge][j] != _token) continue;
+                if (rewardTokensPerMarket[market][j] != _token) continue;
                 // Find the token in the array and swap it with the last element
-                rewardTokensPerGauge[gauge][j] = rewardTokensPerGauge[gauge][
-                    numRewards - 1
-                ];
+                rewardTokensPerMarket[market][j] = rewardTokensPerMarket[
+                    market
+                ][numRewards - 1];
                 // Delete the last element
-                rewardTokensPerGauge[gauge].pop();
+                rewardTokensPerMarket[market].pop();
                 break;
             }
         }
@@ -377,19 +379,19 @@ contract RewardDistributor is
     /// Fetches and stores the caller's LP positions and updates the total liquidity in each market
     /// @dev Can only be called once per user, only necessary if user was an LP prior to this contract's deployment
     function registerPositions() external nonReentrant {
-        uint256 numMarkets = getNumGauges();
+        uint256 numMarkets = getNumMarkets();
         for (uint i; i < numMarkets; ++i) {
             uint idx = clearingHouse.id(i);
-            address gauge = getGaugeAddress(idx);
-            if (lpPositionsPerUser[msg.sender][gauge] != 0)
+            address market = getMarketAddress(idx);
+            if (lpPositionsPerUser[msg.sender][market] != 0)
                 revert RewardDistributor_PositionAlreadyRegistered(
                     msg.sender,
                     i,
-                    lpPositionsPerUser[msg.sender][gauge]
+                    lpPositionsPerUser[msg.sender][market]
                 );
-            uint256 lpPosition = getCurrentPosition(msg.sender, gauge);
-            lpPositionsPerUser[msg.sender][gauge] = lpPosition;
-            totalLiquidityPerMarket[gauge] += lpPosition;
+            uint256 lpPosition = getCurrentPosition(msg.sender, market);
+            lpPositionsPerUser[msg.sender][market] = lpPosition;
+            totalLiquidityPerMarket[market] += lpPosition;
         }
     }
 
@@ -401,16 +403,16 @@ contract RewardDistributor is
     ) external nonReentrant {
         for (uint i; i < _marketIndexes.length; ++i) {
             uint256 idx = _marketIndexes[i];
-            address gauge = getGaugeAddress(idx);
-            if (lpPositionsPerUser[msg.sender][gauge] != 0)
+            address market = getMarketAddress(idx);
+            if (lpPositionsPerUser[msg.sender][market] != 0)
                 revert RewardDistributor_PositionAlreadyRegistered(
                     msg.sender,
                     idx,
-                    lpPositionsPerUser[msg.sender][gauge]
+                    lpPositionsPerUser[msg.sender][market]
                 );
-            uint256 lpPosition = getCurrentPosition(msg.sender, gauge);
-            lpPositionsPerUser[msg.sender][gauge] = lpPosition;
-            totalLiquidityPerMarket[gauge] += lpPosition;
+            uint256 lpPosition = getCurrentPosition(msg.sender, market);
+            lpPositionsPerUser[msg.sender][market] = lpPosition;
+            totalLiquidityPerMarket[market] += lpPosition;
         }
     }
 
@@ -422,15 +424,15 @@ contract RewardDistributor is
     /// Accrues and then distributes rewards for all markets to the given user
     /// @param _user Address of the user to claim rewards for
     function claimRewardsFor(address _user) public override {
-        for (uint i; i < getNumGauges(); ++i) {
-            uint256 idx = getGaugeIdx(i);
-            address gauge = getGaugeAddress(idx);
-            claimRewardsFor(_user, gauge);
+        for (uint i; i < getNumMarkets(); ++i) {
+            uint256 idx = getMarketIdx(i);
+            address market = getMarketAddress(idx);
+            claimRewardsFor(_user, market);
         }
     }
 
-    function claimRewardsFor(address _user, address _gauge) public override {
-        claimRewardsFor(_user, rewardTokensPerGauge[_gauge]);
+    function claimRewardsFor(address _user, address _market) public override {
+        claimRewardsFor(_user, rewardTokensPerMarket[_market]);
     }
 
     /// Accrues and then distributes rewards for all markets to the given user
@@ -439,8 +441,8 @@ contract RewardDistributor is
         address _user,
         address[] memory _rewardTokens
     ) public override whenNotPaused {
-        for (uint i; i < getNumGauges(); ++i) {
-            uint256 idx = getGaugeIdx(i);
+        for (uint i; i < getNumMarkets(); ++i) {
+            uint256 idx = getMarketIdx(i);
             accrueRewards(idx, _user);
         }
         for (uint i; i < _rewardTokens.length; ++i) {
@@ -469,7 +471,7 @@ contract RewardDistributor is
     /// @dev Updating rewards due to changes in LP position is handled by updateStakingPosition
     /// @param user Address of the user to accrue rewards for
     function accrueRewards(address user) external override {
-        for (uint i; i < getNumGauges(); ++i) {
+        for (uint i; i < getNumMarkets(); ++i) {
             uint256 idx = clearingHouse.id(i);
             accrueRewards(idx, user);
         }
@@ -481,42 +483,42 @@ contract RewardDistributor is
     /// @param idx Index of the market in ClearingHouse.perpetuals
     /// @param user Address of the user
     function accrueRewards(uint256 idx, address user) public nonReentrant {
-        address gauge = getGaugeAddress(idx);
+        address market = getMarketAddress(idx);
         if (
             block.timestamp <
-            lastDepositTimeByUserByMarket[user][gauge] +
+            lastDepositTimeByUserByMarket[user][market] +
                 earlyWithdrawalThreshold
         )
             revert RewardDistributor_EarlyRewardAccrual(
                 user,
                 idx,
-                lastDepositTimeByUserByMarket[user][gauge] +
+                lastDepositTimeByUserByMarket[user][market] +
                     earlyWithdrawalThreshold
             );
-        uint256 lpPosition = lpPositionsPerUser[user][gauge];
-        if (lpPosition != getCurrentPosition(user, gauge))
+        uint256 lpPosition = lpPositionsPerUser[user][market];
+        if (lpPosition != getCurrentPosition(user, market))
             // only occurs if the user has a pre-existing liquidity position and has not registered for rewards,
             // since updating LP position calls updateStakingPosition which updates lpPositionsPerUser
             revert RewardDistributor_LpPositionMismatch(
                 user,
                 idx,
                 lpPosition,
-                getCurrentPosition(user, gauge)
+                getCurrentPosition(user, market)
             );
-        if (totalLiquidityPerMarket[gauge] == 0) return;
+        if (totalLiquidityPerMarket[market] == 0) return;
         updateMarketRewards(idx);
-        for (uint i; i < rewardTokensPerGauge[gauge].length; ++i) {
-            address token = rewardTokensPerGauge[gauge][i];
+        for (uint i; i < rewardTokensPerMarket[market].length; ++i) {
+            address token = rewardTokensPerMarket[market][i];
             uint256 newRewards = (lpPosition *
-                (cumulativeRewardPerLpToken[token][gauge] -
-                    cumulativeRewardPerLpTokenPerUser[user][token][gauge])) /
+                (cumulativeRewardPerLpToken[token][market] -
+                    cumulativeRewardPerLpTokenPerUser[user][token][market])) /
                 1e18;
             rewardsAccruedByUser[user][token] += newRewards;
             totalUnclaimedRewards[token] += newRewards;
             cumulativeRewardPerLpTokenPerUser[user][token][
-                gauge
-            ] = cumulativeRewardPerLpToken[token][gauge];
-            emit RewardAccruedToUser(user, token, gauge, newRewards);
+                market
+            ] = cumulativeRewardPerLpToken[token][market];
+            emit RewardAccruedToUser(user, token, market, newRewards);
         }
     }
 
@@ -529,12 +531,12 @@ contract RewardDistributor is
         uint256 idx,
         address user
     ) public view returns (uint256[] memory) {
-        address gauge = getGaugeAddress(idx);
+        address market = getMarketAddress(idx);
         uint256[] memory newRewards = new uint256[](
-            rewardTokensPerGauge[gauge].length
+            rewardTokensPerMarket[market].length
         );
-        for (uint i; i < rewardTokensPerGauge[gauge].length; ++i) {
-            address token = rewardTokensPerGauge[gauge][i];
+        for (uint i; i < rewardTokensPerMarket[market].length; ++i) {
+            address token = rewardTokensPerMarket[market][i];
             newRewards[i] = viewNewRewardAccrual(idx, user, token);
         }
         return newRewards;
@@ -550,32 +552,32 @@ contract RewardDistributor is
         address user,
         address token
     ) public view returns (uint256) {
-        address gauge = getGaugeAddress(idx);
+        address market = getMarketAddress(idx);
         if (
             block.timestamp <
-            lastDepositTimeByUserByMarket[user][gauge] +
+            lastDepositTimeByUserByMarket[user][market] +
                 earlyWithdrawalThreshold
         )
             revert RewardDistributor_EarlyRewardAccrual(
                 user,
                 idx,
-                lastDepositTimeByUserByMarket[user][gauge] +
+                lastDepositTimeByUserByMarket[user][market] +
                     earlyWithdrawalThreshold
             );
-        uint256 lpPosition = lpPositionsPerUser[user][gauge];
-        if (lpPosition != getCurrentPosition(user, gauge))
+        uint256 lpPosition = lpPositionsPerUser[user][market];
+        if (lpPosition != getCurrentPosition(user, market))
             // only occurs if the user has a pre-existing liquidity position and has not registered for rewards,
             // since updating LP position calls updateStakingPosition which updates lpPositionsPerUser
             revert RewardDistributor_LpPositionMismatch(
                 user,
                 idx,
                 lpPosition,
-                getCurrentPosition(user, gauge)
+                getCurrentPosition(user, market)
             );
-        uint256 liquidity = totalLiquidityPerMarket[gauge];
-        if (timeOfLastCumRewardUpdate[gauge] == 0)
-            revert RewardDistributor_UninitializedStartTime(gauge);
-        uint256 deltaTime = block.timestamp - timeOfLastCumRewardUpdate[gauge];
+        uint256 liquidity = totalLiquidityPerMarket[market];
+        if (timeOfLastCumRewardUpdate[market] == 0)
+            revert RewardDistributor_UninitializedStartTime(market);
+        uint256 deltaTime = block.timestamp - timeOfLastCumRewardUpdate[market];
         if (liquidity == 0) return 0;
         RewardInfo memory rewardInfo = rewardInfoByToken[token];
         uint256 totalTimeElapsed = block.timestamp -
@@ -585,13 +587,13 @@ contract RewardDistributor is
             rewardInfo.reductionFactor.pow(totalTimeElapsed.div(365 days))
         );
         uint256 newMarketRewards = (((inflationRate *
-            rewardInfo.gaugeWeights[idx]) / 10000) * deltaTime) / 365 days;
+            rewardInfo.marketWeights[idx]) / 10000) * deltaTime) / 365 days;
         uint256 newCumRewardPerLpToken = cumulativeRewardPerLpToken[token][
-            gauge
+            market
         ] + (newMarketRewards * 1e18) / liquidity;
         uint256 newUserRewards = lpPosition.mul(
             (newCumRewardPerLpToken -
-                cumulativeRewardPerLpTokenPerUser[user][token][gauge])
+                cumulativeRewardPerLpTokenPerUser[user][token][market])
         );
         return newUserRewards;
     }

--- a/src/interfaces/IRewardController.sol
+++ b/src/interfaces/IRewardController.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.16;
 
 import {IClearingHouse} from "increment-protocol/interfaces/IClearingHouse.sol";
 
-interface IGaugeController {
+interface IRewardController {
     /// Emitted when a new reward token is added
     /// @param rewardToken reward token address
     /// @param initialTimestamp timestamp when reward token was added
@@ -52,31 +52,31 @@ interface IGaugeController {
     /// @param newFactor the new reduction factor
     event NewReductionFactor(address indexed rewardToken, uint256 newFactor);
 
-    error GaugeController_AboveMaxRewardTokens(uint256 max);
-    error GaugeController_AboveMaxInflationRate(uint256 rate, uint256 max);
-    error GaugeController_BelowMinReductionFactor(uint256 factor, uint256 min);
-    error GaugeController_InvalidRewardTokenAddress(address token);
-    error GaugeController_IncorrectWeightsCount(
+    error RewardController_AboveMaxRewardTokens(uint256 max);
+    error RewardController_AboveMaxInflationRate(uint256 rate, uint256 max);
+    error RewardController_BelowMinReductionFactor(uint256 factor, uint256 min);
+    error RewardController_InvalidRewardTokenAddress(address token);
+    error RewardController_IncorrectWeightsCount(
         uint256 actual,
         uint256 expected
     );
-    error GaugeController_IncorrectWeightsSum(uint16 actual, uint16 expected);
-    error GaugeController_WeightExceedsMax(uint16 weight, uint16 max);
+    error RewardController_IncorrectWeightsSum(uint16 actual, uint16 expected);
+    error RewardController_WeightExceedsMax(uint16 weight, uint16 max);
 
     function clearingHouse() external view returns (IClearingHouse);
 
-    function rewardTokensPerGauge(
+    function rewardTokensPerMarket(
         address,
         uint256
     ) external view returns (address);
 
-    function getNumGauges() external view returns (uint256);
+    function getNumMarkets() external view returns (uint256);
 
-    function getMaxGaugeIdx() external view returns (uint256);
+    function getMaxMarketIdx() external view returns (uint256);
 
-    function getGaugeAddress(uint256) external view returns (address);
+    function getMarketAddress(uint256) external view returns (address);
 
-    function getGaugeIdx(uint256) external view returns (uint256);
+    function getMarketIdx(uint256) external view returns (uint256);
 
     function getRewardTokenCount(address) external view returns (uint256);
 
@@ -88,11 +88,11 @@ interface IGaugeController {
 
     function getReductionFactor(address) external view returns (uint256);
 
-    function getGaugeWeights(address) external view returns (uint16[] memory);
+    function getRewardWeights(address) external view returns (uint16[] memory);
 
     function updateMarketRewards(uint256) external;
 
-    function updateGaugeWeights(address, uint16[] calldata) external;
+    function updateRewardWeights(address, uint16[] calldata) external;
 
     function updateInflationRate(address, uint256) external;
 


### PR DESCRIPTION
Undoes a mistake  in which I moved division by liquidity from the `updateMarketReward` function to the `updateStakingPosition` function. `cumulativeRewardPerLpToken` once again represents a number of reward tokens per LP token, rather than just a total number of reward tokens. This is critical for factoring in changes in total liquidity over time, between calls to `updateStakingPosition`.

Also, all occurrences of the word "gauge" have been replaced by the words "market" or "reward". This is because a gauge system typically involves many separate gauge contracts, one per market contract, in which users stake their voting escrow tokens (i.e., veBAL) to dynamically vote on the distribution weights of rewards. Our system is more like Compound's Comptroller, in that a single contract keeps track of liquidity across all markets, and distributes rewards according to per-market weights determined by governance proposals.