### PR TITLE
Refactor RewardDistributor inheritance, separating PerpRewardDistributor and SafetyModule

### DIFF
--- a/src/PerpRewardDistributor.sol
+++ b/src/PerpRewardDistributor.sol
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.16;
+
+// contracts
+import "./RewardDistributor.sol";
+
+// interfaces
+import "./interfaces/IPerpRewardDistributor.sol";
+
+contract PerpRewardDistributor is RewardDistributor, IPerpRewardDistributor {
+    using SafeERC20 for IERC20Metadata;
+    using PRBMathUD60x18 for uint256;
+
+    /// @notice Clearing House contract
+    IClearingHouse public clearingHouse;
+
+    /// @notice Amount of time after which LPs can remove liquidity without penalties
+    uint256 public override earlyWithdrawalThreshold;
+
+    modifier onlyClearingHouse() {
+        if (msg.sender != address(clearingHouse))
+            revert PerpRewardDistributor_CallerIsNotClearingHouse(msg.sender);
+        _;
+    }
+
+    constructor(
+        uint256 _initialInflationRate,
+        uint256 _initialReductionFactor,
+        address _rewardToken,
+        address _clearingHouse,
+        address _tokenVault,
+        uint256 _earlyWithdrawalThreshold,
+        uint16[] memory _initialRewardWeights
+    )
+        RewardDistributor(
+            _initialInflationRate,
+            _initialReductionFactor,
+            _tokenVault
+        )
+    {
+        clearingHouse = IClearingHouse(_clearingHouse);
+        earlyWithdrawalThreshold = _earlyWithdrawalThreshold;
+        // Add reward token info
+        rewardInfoByToken[_rewardToken] = RewardInfo({
+            token: IERC20Metadata(_rewardToken),
+            initialTimestamp: block.timestamp,
+            inflationRate: _initialInflationRate,
+            reductionFactor: _initialReductionFactor,
+            marketWeights: _initialRewardWeights
+        });
+        for (uint256 i; i < getNumMarkets(); ++i) {
+            uint256 idx = getMarketIdx(i);
+            address market = getMarketAddress(idx);
+            rewardTokensPerMarket[market].push(_rewardToken);
+            timeOfLastCumRewardUpdate[market] = block.timestamp;
+        }
+        emit RewardTokenAdded(
+            _rewardToken,
+            block.timestamp,
+            _initialInflationRate,
+            _initialReductionFactor
+        );
+    }
+
+    /* ****************** */
+    /*   Market Getters   */
+    /* ****************** */
+
+    /// @inheritdoc RewardController
+    function getNumMarkets() public view override returns (uint256) {
+        return clearingHouse.getNumMarkets();
+    }
+
+    /// @inheritdoc RewardController
+    function getMaxMarketIdx() public view override returns (uint256) {
+        return clearingHouse.marketIds() - 1;
+    }
+
+    /// @inheritdoc RewardController
+    function getMarketAddress(
+        uint256 index
+    ) public view override returns (address) {
+        if (index > getMaxMarketIdx())
+            revert RewardDistributor_InvalidMarketIndex(
+                index,
+                getMaxMarketIdx()
+            );
+        return address(clearingHouse.perpetuals(index));
+    }
+
+    /// @inheritdoc RewardController
+    function getMarketIdx(uint256 i) public view override returns (uint256) {
+        return clearingHouse.id(i);
+    }
+
+    /// @inheritdoc RewardController
+    function getAllowlistIdx(
+        uint256 idx
+    ) public view override returns (uint256) {
+        for (uint i; i < getNumMarkets(); ++i) {
+            if (getMarketIdx(i) == idx) return i;
+        }
+        revert RewardDistributor_MarketIndexNotAllowlisted(idx);
+    }
+
+    /// @inheritdoc RewardDistributor
+    function getCurrentPosition(
+        address lp,
+        address market
+    ) public view override returns (uint256) {
+        return IPerpetual(market).getLpLiquidity(lp);
+    }
+
+    /* ****************** */
+    /*   Reward Accrual   */
+    /* ****************** */
+
+    /// Accrues rewards and updates the stored LP position of a user and the total LP of a market
+    /// @dev Executes whenever a user's liquidity is updated for any reason
+    /// @param idx Index of the perpetual market in the ClearingHouse
+    /// @param user Address of the liquidity provier
+    function updateStakingPosition(
+        uint256 idx,
+        address user
+    ) external virtual override nonReentrant onlyClearingHouse {
+        updateMarketRewards(idx);
+        address market = getMarketAddress(idx);
+        uint256 prevLpPosition = lpPositionsPerUser[user][market];
+        uint256 newLpPosition = getCurrentPosition(user, market);
+        for (uint256 i; i < rewardTokensPerMarket[market].length; ++i) {
+            address token = rewardTokensPerMarket[market][i];
+            /// newRewards = user.lpBalance / global.lpBalance x (global.cumRewardPerLpToken - user.cumRewardPerLpToken)
+            uint256 newRewards = (prevLpPosition *
+                (cumulativeRewardPerLpToken[token][market] -
+                    cumulativeRewardPerLpTokenPerUser[user][token][market])) /
+                1e18;
+            if (newLpPosition >= prevLpPosition) {
+                // Added liquidity
+                if (lastDepositTimeByUserByMarket[user][market] == 0) {
+                    lastDepositTimeByUserByMarket[user][market] = block
+                        .timestamp;
+                }
+            } else {
+                // Removed liquidity - need to check if within early withdrawal threshold
+                uint256 deltaTime = block.timestamp -
+                    lastDepositTimeByUserByMarket[user][market];
+                if (deltaTime < earlyWithdrawalThreshold) {
+                    // Early withdrawal - apply penalty
+                    newRewards -=
+                        (newRewards * (earlyWithdrawalThreshold - deltaTime)) /
+                        earlyWithdrawalThreshold;
+                }
+                if (newLpPosition > 0) {
+                    // Reset timer
+                    lastDepositTimeByUserByMarket[user][market] = block
+                        .timestamp;
+                } else {
+                    // Full withdrawal, so next deposit is an initial deposit
+                    lastDepositTimeByUserByMarket[user][market] = 0;
+                }
+            }
+            cumulativeRewardPerLpTokenPerUser[user][token][
+                market
+            ] = cumulativeRewardPerLpToken[token][market];
+            if (newRewards > 0) {
+                rewardsAccruedByUser[user][token] += newRewards;
+                totalUnclaimedRewards[token] += newRewards;
+                emit RewardAccruedToUser(
+                    user,
+                    token,
+                    address(market),
+                    newRewards
+                );
+            }
+        }
+        totalLiquidityPerMarket[market] =
+            totalLiquidityPerMarket[market] +
+            newLpPosition -
+            prevLpPosition;
+        lpPositionsPerUser[user][market] = newLpPosition;
+    }
+
+    /* ****************** */
+    /*    External User   */
+    /* ****************** */
+
+    /// Accrues rewards to a user for a given market
+    /// @notice Assumes LP position hasn't changed since last accrual
+    /// @dev Updating rewards due to changes in LP position is handled by updateStakingPosition
+    /// @param idx Index of the market in ClearingHouse.perpetuals
+    /// @param user Address of the user
+    function accrueRewards(
+        uint256 idx,
+        address user
+    ) public virtual override nonReentrant {
+        address market = getMarketAddress(idx);
+        if (
+            block.timestamp <
+            lastDepositTimeByUserByMarket[user][market] +
+                earlyWithdrawalThreshold
+        )
+            revert RewardDistributor_EarlyRewardAccrual(
+                user,
+                idx,
+                lastDepositTimeByUserByMarket[user][market] +
+                    earlyWithdrawalThreshold
+            );
+        uint256 lpPosition = lpPositionsPerUser[user][market];
+        if (lpPosition != getCurrentPosition(user, market))
+            // only occurs if the user has a pre-existing liquidity position and has not registered for rewards,
+            // since updating LP position calls updateStakingPosition which updates lpPositionsPerUser
+            revert RewardDistributor_LpPositionMismatch(
+                user,
+                idx,
+                lpPosition,
+                getCurrentPosition(user, market)
+            );
+        if (totalLiquidityPerMarket[market] == 0) return;
+        updateMarketRewards(idx);
+        for (uint i; i < rewardTokensPerMarket[market].length; ++i) {
+            address token = rewardTokensPerMarket[market][i];
+            uint256 newRewards = (lpPosition *
+                (cumulativeRewardPerLpToken[token][market] -
+                    cumulativeRewardPerLpTokenPerUser[user][token][market])) /
+                1e18;
+            rewardsAccruedByUser[user][token] += newRewards;
+            totalUnclaimedRewards[token] += newRewards;
+            cumulativeRewardPerLpTokenPerUser[user][token][
+                market
+            ] = cumulativeRewardPerLpToken[token][market];
+            emit RewardAccruedToUser(user, token, market, newRewards);
+        }
+    }
+
+    /// Returns the amount of rewards that would be accrued to a user for a given market and reward token
+    /// @param idx Index of the market in ClearingHouse.perpetuals
+    /// @param user Address of the user
+    /// @param token Address of the reward token
+    /// @return Amount of new rewards that would be accrued to the user
+    function viewNewRewardAccrual(
+        uint256 idx,
+        address user,
+        address token
+    ) public view override returns (uint256) {
+        address market = getMarketAddress(idx);
+        if (
+            block.timestamp <
+            lastDepositTimeByUserByMarket[user][market] +
+                earlyWithdrawalThreshold
+        )
+            revert RewardDistributor_EarlyRewardAccrual(
+                user,
+                idx,
+                lastDepositTimeByUserByMarket[user][market] +
+                    earlyWithdrawalThreshold
+            );
+        uint256 lpPosition = lpPositionsPerUser[user][market];
+        if (lpPosition != getCurrentPosition(user, market))
+            // only occurs if the user has a pre-existing liquidity position and has not registered for rewards,
+            // since updating LP position calls updateStakingPosition which updates lpPositionsPerUser
+            revert RewardDistributor_LpPositionMismatch(
+                user,
+                idx,
+                lpPosition,
+                getCurrentPosition(user, market)
+            );
+        uint256 liquidity = totalLiquidityPerMarket[market];
+        if (timeOfLastCumRewardUpdate[market] == 0)
+            revert RewardDistributor_UninitializedStartTime(market);
+        uint256 deltaTime = block.timestamp - timeOfLastCumRewardUpdate[market];
+        if (liquidity == 0) return 0;
+        RewardInfo memory rewardInfo = rewardInfoByToken[token];
+        uint256 totalTimeElapsed = block.timestamp -
+            rewardInfo.initialTimestamp;
+        // Calculate the new cumRewardPerLpToken by adding (inflationRatePerSecond x guageWeight x deltaTime) to the previous cumRewardPerLpToken
+        uint256 inflationRate = rewardInfo.inflationRate.div(
+            rewardInfo.reductionFactor.pow(totalTimeElapsed.div(365 days))
+        );
+        uint256 newMarketRewards = (((inflationRate *
+            rewardInfo.marketWeights[idx]) / 10000) * deltaTime) / 365 days;
+        uint256 newCumRewardPerLpToken = cumulativeRewardPerLpToken[token][
+            market
+        ] + (newMarketRewards * 1e18) / liquidity;
+        uint256 newUserRewards = lpPosition.mul(
+            (newCumRewardPerLpToken -
+                cumulativeRewardPerLpTokenPerUser[user][token][market])
+        );
+        return newUserRewards;
+    }
+
+    function paused() public view override returns (bool) {
+        return super.paused() || Pausable(address(clearingHouse)).paused();
+    }
+}

--- a/src/RewardController.sol
+++ b/src/RewardController.sol
@@ -68,11 +68,11 @@ abstract contract RewardController is
 
     /// Updates the reward accumulator for a given market
     /// @dev Executes when any of the following variables are changed: inflationRate, marketWeights, liquidity
-    /// @param idx Index of the perpetual market in the ClearingHouse
+    /// @param idx Index of the market
     function updateMarketRewards(uint256 idx) public virtual;
 
     /// Gets the number of markets to be used for reward distribution
-    /// @dev Markets are the perpetual markets (for the MarketRewardDistributor) or staked tokens (for the SafetyModule)
+    /// @dev Markets are the perpetual markets (for the PerpRewardDistributor) or staked tokens (for the SafetyModule)
     /// @return Number of markets
     function getNumMarkets() public view virtual returns (uint256);
 
@@ -81,7 +81,7 @@ abstract contract RewardController is
     function getMaxMarketIdx() public view virtual returns (uint256);
 
     /// Gets the address of a market
-    /// @dev Markets are the perpetual markets (for the MarketRewardDistributor) or staked tokens (for the SafetyModule)
+    /// @dev Markets are the perpetual markets (for the PerpRewardDistributor) or staked tokens (for the SafetyModule)
     /// @param idx Index of the market
     /// @return Address of the market
     function getMarketAddress(
@@ -89,13 +89,13 @@ abstract contract RewardController is
     ) public view virtual returns (address);
 
     /// Gets the index of an allowlisted market
-    /// @dev Markets are the perpetual markets (for the MarketRewardDistributor) or staked tokens (for the SafetyModule)
+    /// @dev Markets are the perpetual markets (for the PerpRewardDistributor) or staked tokens (for the SafetyModule)
     /// @param i Index of the market in the allowlist ids
     /// @return Index of the market in the market list
     function getMarketIdx(uint256 i) public view virtual returns (uint256);
 
     /// Gets the index of the market in the allowlist
-    /// @dev Markets are the perpetual markets (for the MarketRewardDistributor) or staked tokens (for the SafetyModule)
+    /// @dev Markets are the perpetual markets (for the PerpRewardDistributor) or staked tokens (for the SafetyModule)
     /// @param idx Index of the market in the market list
     /// @return Index of the market in the allowlist ids
     function getAllowlistIdx(uint256 idx) public view virtual returns (uint256);

--- a/src/interfaces/IPerpRewardDistributor.sol
+++ b/src/interfaces/IPerpRewardDistributor.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.16;
+
+// interfaces
+import {IRewardDistributor} from "./IRewardDistributor.sol";
+import {IClearingHouse} from "increment-protocol/interfaces/IClearingHouse.sol";
+
+interface IPerpRewardDistributor {
+    error PerpRewardDistributor_CallerIsNotClearingHouse(address caller);
+
+    function clearingHouse() external view returns (IClearingHouse);
+
+    function earlyWithdrawalThreshold() external view returns (uint256);
+}

--- a/src/interfaces/IRewardController.sol
+++ b/src/interfaces/IRewardController.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.16;
 
-import {IClearingHouse} from "increment-protocol/interfaces/IClearingHouse.sol";
-
 interface IRewardController {
     /// Emitted when a new reward token is added
     /// @param rewardToken reward token address
@@ -63,8 +61,6 @@ interface IRewardController {
     error RewardController_IncorrectWeightsSum(uint16 actual, uint16 expected);
     error RewardController_WeightExceedsMax(uint16 weight, uint16 max);
 
-    function clearingHouse() external view returns (IClearingHouse);
-
     function rewardTokensPerMarket(
         address,
         uint256
@@ -77,6 +73,8 @@ interface IRewardController {
     function getMarketAddress(uint256) external view returns (address);
 
     function getMarketIdx(uint256) external view returns (uint256);
+
+    function getAllowlistIdx(uint256 idx) external view returns (uint256);
 
     function getRewardTokenCount(address) external view returns (uint256);
 

--- a/src/interfaces/IRewardDistributor.sol
+++ b/src/interfaces/IRewardDistributor.sol
@@ -3,14 +3,13 @@ pragma solidity 0.8.16;
 
 // interfaces
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import {IClearingHouse} from "increment-protocol/interfaces/IClearingHouse.sol";
 import {IPerpetual} from "increment-protocol/interfaces/IPerpetual.sol";
 
 interface IRewardDistributor {
     /// Emitted when rewards are accrued to an LP
     /// @param lp Address of the liquidity provier
     /// @param rewardToken Address of the reward token
-    /// @param perpetual Address of the perpetual market
+    /// @param perpetual Address of the market
     /// @param reward Amount of reward accrued
     event RewardAccruedToUser(
         address indexed lp,
@@ -20,7 +19,7 @@ interface IRewardDistributor {
     );
 
     /// Emitted when rewards are accrued to a market
-    /// @param perpetual Address of the perpetual market
+    /// @param perpetual Address of the market
     /// @param rewardToken Address of the reward token
     /// @param reward Amount of reward accrued
     event RewardAccruedToMarket(
@@ -41,7 +40,7 @@ interface IRewardDistributor {
 
     /// Emitted when an LP's position is changed in the reward distributor
     /// @param lp Address of the liquidity provier
-    /// @param perpetualIndex Index of the perpetual market in the ClearingHouse
+    /// @param perpetualIndex Index of the market
     /// @param prevPosition Previous LP position of the user
     /// @param newPosition New LP position of the user
     event PositionUpdated(
@@ -50,8 +49,6 @@ interface IRewardDistributor {
         uint256 prevPosition,
         uint256 newPosition
     );
-
-    error RewardDistributor_CallerIsNotClearingHouse(address caller);
     error RewardDistributor_InvalidMarketIndex(uint256 index, uint256 maxIndex);
     error RewardDistributor_MarketIndexNotAllowlisted(uint256 index);
     error RewardDistributor_UninitializedStartTime(address gauge);
@@ -73,8 +70,6 @@ interface IRewardDistributor {
         uint256 prevPosition,
         uint256 newPosition
     );
-
-    function earlyWithdrawalThreshold() external view returns (uint256);
 
     function getCurrentPosition(
         address,

--- a/test/RewardsTest.sol
+++ b/test/RewardsTest.sol
@@ -11,7 +11,7 @@ import "increment-protocol/tokens/VBase.sol";
 import "increment-protocol/tokens/VQuote.sol";
 import "increment-protocol/mocks/MockAggregator.sol";
 import "@increment-governance/IncrementToken.sol";
-import "../src/RewardDistributor.sol";
+import "../src/PerpRewardDistributor.sol";
 import {EcosystemReserve, IERC20 as AaveIERC20} from "../src/EcosystemReserve.sol";
 
 // interfaces
@@ -54,7 +54,7 @@ contract RewardsTest is PerpetualUtils {
     IncrementToken public rewardsToken2;
 
     EcosystemReserve public rewardVault;
-    RewardDistributor public rewardsDistributor;
+    PerpRewardDistributor public rewardsDistributor;
 
     function setUp() public virtual override {
         deal(liquidityProviderOne, 100 ether);
@@ -122,7 +122,7 @@ contract RewardsTest is PerpetualUtils {
         weights[0] = 7500;
         weights[1] = 2500;
 
-        rewardsDistributor = new RewardDistributor(
+        rewardsDistributor = new PerpRewardDistributor(
             INITIAL_INFLATION_RATE,
             INITIAL_REDUCTION_FACTOR,
             address(rewardsToken),
@@ -1367,7 +1367,7 @@ contract RewardsTest is PerpetualUtils {
         weights[0] = 7500;
         weights[1] = 2500;
 
-        RewardDistributor newRewardsDistributor = new RewardDistributor(
+        PerpRewardDistributor newRewardsDistributor = new PerpRewardDistributor(
             INITIAL_INFLATION_RATE,
             INITIAL_REDUCTION_FACTOR,
             address(rewardsToken),
@@ -1500,7 +1500,7 @@ contract RewardsTest is PerpetualUtils {
         // updateStakingPosition
         vm.expectRevert(
             abi.encodeWithSignature(
-                "RewardDistributor_CallerIsNotClearingHouse(address)",
+                "PerpRewardDistributor_CallerIsNotClearingHouse(address)",
                 address(this)
             )
         );

--- a/test/SafetyModuleTest.sol
+++ b/test/SafetyModuleTest.sol
@@ -76,6 +76,10 @@ contract SafetyModuleTest is PerpetualUtils {
         // Deploy the Ecosystem Reserve vault
         rewardVault = new EcosystemReserve(address(this));
 
+        uint16[] memory weights = new uint16[](2);
+        weights[0] = 5000;
+        weights[1] = 5000;
+
         // Deploy safety module
         safetyModule = new SafetyModule(
             address(vault),
@@ -86,8 +90,8 @@ contract SafetyModuleTest is PerpetualUtils {
             INITIAL_INFLATION_RATE,
             INITIAL_REDUCTION_FACTOR,
             address(rewardsToken),
-            address(clearingHouse),
-            address(rewardVault)
+            address(rewardVault),
+            weights
         );
         safetyModule.setMaxRewardMultiplier(INITIAL_MAX_MULTIPLIER);
         safetyModule.setSmoothingValue(INITIAL_SMOOTHING_VALUE);


### PR DESCRIPTION
Make RewardDistributor an abstract contract, and add PerpRewardDistributor with logic specific to perp market rewards in order to separate that logic from the SafetyModule