### PR TITLE
Rename `inflationRate` to `initialInflationRate`

### DIFF
--- a/src/RewardController.sol
+++ b/src/RewardController.sol
@@ -25,7 +25,7 @@ abstract contract RewardController is
     struct RewardInfo {
         IERC20Metadata token; // Address of the reward token
         uint256 initialTimestamp; // Time when the reward token was added
-        uint256 inflationRate; // Amount of reward token emitted per year
+        uint256 initialInflationRate; // Amount of reward token emitted per year
         uint256 reductionFactor; // Factor by which the inflation rate is reduced each year
         uint16[] marketWeights; // Weights are basis points, i.e., 100 = 1%, 10000 = 100%
     }
@@ -67,7 +67,7 @@ abstract contract RewardController is
     /* ****************** */
 
     /// Updates the reward accumulator for a given market
-    /// @dev Executes when any of the following variables are changed: inflationRate, marketWeights, liquidity
+    /// @dev Executes when any of the following variables are changed: initialInflationRate, marketWeights, liquidity
     /// @param idx Index of the perpetual market in the ClearingHouse
     function updateMarketRewards(uint256 idx) public virtual;
 
@@ -121,10 +121,10 @@ abstract contract RewardController is
 
     /// Gets the inflation rate of a reward token (w/o factoring in reduction factor)
     /// @param rewardToken Address of the reward token
-    function getBaseInflationRate(
+    function getInitialInflationRate(
         address rewardToken
     ) external view returns (uint256) {
-        return rewardInfoByToken[rewardToken].inflationRate;
+        return rewardInfoByToken[rewardToken].initialInflationRate;
     }
 
     /// Gets the current inflation rate of a reward token (factoring in reduction factor)
@@ -137,7 +137,7 @@ abstract contract RewardController is
         uint256 totalTimeElapsed = block.timestamp -
             rewardInfo.initialTimestamp;
         return
-            rewardInfo.inflationRate.div(
+            rewardInfo.initialInflationRate.div(
                 rewardInfo.reductionFactor.pow(totalTimeElapsed.div(365 days))
             );
     }
@@ -232,8 +232,8 @@ abstract contract RewardController is
             uint256 idx = getMarketIdx(i);
             updateMarketRewards(idx);
         }
-        rewardInfoByToken[_token].inflationRate = _newInflationRate;
-        emit NewInflationRate(_token, _newInflationRate);
+        rewardInfoByToken[_token].initialInflationRate = _newInflationRate;
+        emit NewInitialInflationRate(_token, _newInflationRate);
     }
 
     /// Sets the reduction factor used to reduce emissions over time

--- a/src/RewardDistributor.sol
+++ b/src/RewardDistributor.sol
@@ -92,7 +92,7 @@ contract RewardDistributor is
         rewardInfoByToken[_rewardToken] = RewardInfo({
             token: IERC20Metadata(_rewardToken),
             initialTimestamp: block.timestamp,
-            inflationRate: _initialInflationRate,
+            initialInflationRate: _initialInflationRate,
             reductionFactor: _initialReductionFactor,
             marketWeights: _initialRewardWeights
         });
@@ -191,7 +191,7 @@ contract RewardDistributor is
                 rewardInfo.initialTimestamp;
             // Calculate the new cumRewardPerLpToken by adding (inflationRatePerSecond x marketWeight x deltaTime) / liquidity to the previous cumRewardPerLpToken
             uint256 inflationRate = (
-                rewardInfo.inflationRate.div(
+                rewardInfo.initialInflationRate.div(
                     rewardInfo.reductionFactor.pow(
                         totalTimeElapsed.div(365 days)
                     )
@@ -326,7 +326,7 @@ contract RewardDistributor is
         rewardInfoByToken[_rewardToken] = RewardInfo({
             token: IERC20Metadata(_rewardToken),
             initialTimestamp: block.timestamp,
-            inflationRate: _initialInflationRate,
+            initialInflationRate: _initialInflationRate,
             reductionFactor: _initialReductionFactor,
             marketWeights: _marketWeights
         });
@@ -596,7 +596,7 @@ contract RewardDistributor is
         uint256 totalTimeElapsed = block.timestamp -
             rewardInfo.initialTimestamp;
         // Calculate the new cumRewardPerLpToken by adding (inflationRatePerSecond x guageWeight x deltaTime) to the previous cumRewardPerLpToken
-        uint256 inflationRate = rewardInfo.inflationRate.div(
+        uint256 inflationRate = rewardInfo.initialInflationRate.div(
             rewardInfo.reductionFactor.pow(totalTimeElapsed.div(365 days))
         );
         uint256 newMarketRewards = (((inflationRate *

--- a/src/interfaces/IRewardController.sol
+++ b/src/interfaces/IRewardController.sol
@@ -46,7 +46,7 @@ interface IRewardController {
 
     /// Emitted when a new inflation rate is set by governance
     /// @param newRate the new inflation rate
-    event NewInflationRate(address indexed rewardToken, uint256 newRate);
+    event NewInitialInflationRate(address indexed rewardToken, uint256 newRate);
 
     /// Emitted when a new reduction factor is set by governance
     /// @param newFactor the new reduction factor
@@ -82,7 +82,7 @@ interface IRewardController {
 
     function getInitialTimestamp(address) external view returns (uint256);
 
-    function getBaseInflationRate(address) external view returns (uint256);
+    function getInitialInflationRate(address) external view returns (uint256);
 
     function getInflationRate(address) external view returns (uint256);
 


### PR DESCRIPTION
Rename `inflationRate` to `initialInflationRate` in `RewardInfo` struct to avoid confusion, since the actual inflation rate factors in the reduction factor and time elapsed since `RewardInfo.initialTimestamp`